### PR TITLE
Backwards Compatibility Work

### DIFF
--- a/models/backwards_compatibility/stg_facebook_ads__app_link.sql
+++ b/models/backwards_compatibility/stg_facebook_ads__app_link.sql
@@ -1,0 +1,50 @@
+with base as (
+
+  select *
+  from {{ ref('stg_facebook_ads__creative_history') }}
+
+), required_fields as (
+
+  select 
+    _fivetran_id, 
+    creative_id, 
+    template_app_link_spec_ios_dummy,
+    template_app_link_spec_ipad_dummy,
+    template_app_link_spec_android_dummy,
+    template_app_link_spec_iphone_dummy
+  from base
+
+{% for app in ['ios','ipad','android','iphone'] %}
+  
+), unnested_{{ app }} as (
+
+  select 
+    _fivetran_id,
+    creative_id,
+    '{{ app }}' as app_type,
+    json_extract_scalar(element, '$.index') as index,
+    json_extract_scalar(element, '$.app_name') as app_name,
+    json_extract_scalar(element, '$.app_store_id') as app_store_id,
+    json_extract_scalar(element, '$.class_name') as class_name,
+    json_extract_scalar(element, '$.package_name') as package_name,
+    json_extract_scalar(element, '$.template_page') as template_page
+  from base
+  left join unnest(json_extract_array(template_app_link_spec_{{ app }}_dummy)) as element
+
+{% endfor %}
+
+), unioned as (
+
+    select * from unnested_ios
+    union all
+    select * from unnested_iphone
+    union all
+    select * from unnested_ipad
+    union all
+    select * from unnested_android
+
+)
+
+select *
+from unioned
+order by _fivetran_id

--- a/models/backwards_compatibility/stg_facebook_ads__carousel_media.sql
+++ b/models/backwards_compatibility/stg_facebook_ads__carousel_media.sql
@@ -1,0 +1,34 @@
+with base as (
+
+    select *
+    from {{ ref('stg_facebook_ads__creative_history') }}
+
+), required_fields as (
+
+    select 
+        _fivetran_id, 
+        creative_id, 
+        object_story_link_data_child_attachments,
+        object_story_link_data_caption, 
+        object_story_link_data_description, 
+        object_story_link_data_link, 
+        object_story_link_data_message
+    from base
+    where object_story_link_data_child_attachments is not null
+  
+), unnested as (
+
+    select 
+        _fivetran_id,
+        creative_id,
+        object_story_link_data_caption as caption, 
+        object_story_link_data_description as description, 
+        object_story_link_data_message as message,
+        json_extract_scalar(element, '$.link') as link
+    from base
+    left join unnest(json_extract_array(object_story_link_data_child_attachments)) as element
+
+)
+
+select *
+from unnested

--- a/models/backwards_compatibility/stg_facebook_ads__creative_history_asset_feed_spec_link_url.sql
+++ b/models/backwards_compatibility/stg_facebook_ads__creative_history_asset_feed_spec_link_url.sql
@@ -1,0 +1,28 @@
+with base as (
+
+    select *
+    from {{ ref('stg_facebook_ads__creative_history') }}
+
+), required_fields as (  
+  
+    select 
+        _fivetran_id, 
+        asset_feed_spec_link_urls
+    from base
+    where asset_feed_spec_link_urls is not null
+  
+), unnested as (
+
+    select 
+        _fivetran_id,
+        nullif(json_extract_scalar(elements,'$.display_url'),'') as display_url,
+        nullif(json_extract_scalar(elements,'$.website_url'),'') as website_url,
+        row_number() over (partition by _fivetran_id) as index
+    from required_fields
+    left join unnest(json_extract_array(asset_feed_spec_link_urls)) as elements
+
+)
+
+select *
+from unnested
+

--- a/models/backwards_compatibility/stg_facebook_ads__url_tag.sql
+++ b/models/backwards_compatibility/stg_facebook_ads__url_tag.sql
@@ -1,0 +1,51 @@
+{{ config(materialized='table') }}
+
+with base as (
+
+    select *
+    from {{ ref('stg_facebook_ads__creative_history') }}
+
+), required_fields as (
+
+    select 
+        _fivetran_id,
+        creative_id,
+        url_tags
+    from base
+    where url_tags is not null
+
+), cleaned_json as (
+
+    select 
+        _fivetran_id,
+        creative_id,
+        json_extract_array(replace(trim(url_tags, '"'),'\\','')) as cleaned_url_tags
+    from required_fields
+
+), unnested as (
+    
+    select _fivetran_id, creative_id, url_tag_element
+    from cleaned_json
+    left join unnest(cleaned_url_tags) as url_tag_element
+    where cleaned_url_tags is not null
+  
+), fields as (
+    
+    select 
+        _fivetran_id,
+        creative_id,
+        json_extract_scalar(url_tag_element, '$.key') as key,
+        json_extract_scalar(url_tag_element, '$.value') as value,
+        json_extract_scalar(url_tag_element, '$.type') as type
+    from unnested
+  
+), filtered as (
+    
+    select *
+    from fields
+    where type = 'AD'
+  
+)
+
+select *
+from filtered

--- a/models/stg_facebook_ads__creative_history.sql
+++ b/models/stg_facebook_ads__creative_history.sql
@@ -23,6 +23,7 @@ fields as (
 fields_xf as (
     
     select 
+        _fivetran_id,
         id as creative_id,
         account_id,
         name as creative_name,
@@ -36,6 +37,16 @@ fields_xf as (
         {{ dbt_utils.get_url_parameter(url_field, 'utm_content') }} as utm_content,
         {{ dbt_utils.get_url_parameter(url_field, 'utm_term') }} as utm_term,
         url_tags,
+        asset_feed_spec_link_urls,
+        object_story_link_data_child_attachments,
+        object_story_link_data_caption, 
+        object_story_link_data_description, 
+        object_story_link_data_link, 
+        object_story_link_data_message,
+        '[{"app_name": "fivetran_ios","app_store_id": "567890","url": "https://fivetran.com","index": 0}]' as template_app_link_spec_ios_dummy,
+        '[{"app_name": "fivetran_ios","app_store_id": "567890","url": "https://fivetran.com","index": 0}]' as template_app_link_spec_ipad_dummy,
+        '[{"app_name": "fivetran_ios","app_store_id": "567890","url": "https://fivetran.com","index": 0}]' as template_app_link_spec_android_dummy,
+        '[{"app_name": "fivetran_ios","app_store_id": "567890","url": "https://fivetran.com","index": 0}]' as template_app_link_spec_iphone_dummy,
         row_number() over (partition by id order by _fivetran_synced desc) = 1 as is_most_recent_record
     from fields
 ),

--- a/models/stg_facebook_ads__creative_history.sql
+++ b/models/stg_facebook_ads__creative_history.sql
@@ -1,5 +1,3 @@
-{% set url_field = "coalesce(page_link,template_page_link)" %}
-
 with base as (
 
     select * 
@@ -27,15 +25,8 @@ fields_xf as (
         id as creative_id,
         account_id,
         name as creative_name,
-        {{ url_field }} as url,
-        {{ dbt_utils.split_part(url_field, "'?'", 1) }} as base_url,
-        {{ dbt_utils.get_url_host(url_field) }} as url_host,
-        '/' || {{ dbt_utils.get_url_path(url_field) }} as url_path,
-        {{ dbt_utils.get_url_parameter(url_field, 'utm_source') }} as utm_source,
-        {{ dbt_utils.get_url_parameter(url_field, 'utm_medium') }} as utm_medium,
-        {{ dbt_utils.get_url_parameter(url_field, 'utm_campaign') }} as utm_campaign,
-        {{ dbt_utils.get_url_parameter(url_field, 'utm_content') }} as utm_content,
-        {{ dbt_utils.get_url_parameter(url_field, 'utm_term') }} as utm_term,
+        page_link,
+        template_page_link,
         url_tags,
         asset_feed_spec_link_urls,
         object_story_link_data_child_attachments,

--- a/packages.yml
+++ b/packages.yml
@@ -5,3 +5,5 @@ packages:
   - git: "https://github.com/fivetran/dbt_fivetran_utils.git"
     revision: master
     warn-unpinned: false
+
+  # - local: ../dbt_facebook_ads_creative_history


### PR DESCRIPTION
@fivetran-kristin I've started the backwards compatibility work here for ease. (I'll move it over once we're happy with the structure.)

The only one I'm worried about is the `app_link` table. From the data Manju sent, I was able to get most of the columns, but there are three that I'm still unclear on: `class_name`, `package_name`, and `template_page`. I'm hoping they are just not in the JSON he sent as an example, but I've asked him to confirm [here](https://fivetran.slack.com/archives/G01J60T952T/p1612546204000200).

This PR is compatible with [this PR](https://github.com/fivetran/dbt_facebook_ads/pull/1) in the transform package.